### PR TITLE
Added INTERNET permission to manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="udacity.pokemon">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
In the "Skeleton Code" of the app, the INTERNET permission is missing in the manifest, even though this is not a part of any of the quizzes of the practice set in lesson 4. (So after completing all the quizzes successfully the app does not work as expected)

**I added the permission and did not change anything else.**

